### PR TITLE
Fix format_output_json method in playwright scraper

### DIFF
--- a/src/mindvault/bookmarks/twitter/scraper/playwright_scraper.py
+++ b/src/mindvault/bookmarks/twitter/scraper/playwright_scraper.py
@@ -73,10 +73,14 @@ class PlaywrightScraper(BaseTweetScraper):
             # Follow the same pattern as the experimental script
             if "data" in item and "threaded_conversation_with_injections_v2" in item["data"]:
                 instructions = item["data"]["threaded_conversation_with_injections_v2"]["instructions"]
-                if instructions and len(instructions) > 0 and "entries" in instructions[0]:
-                    out["threaded_conversation_with_injections_v2"]["instructions"][0]["entries"].extend(
-                        instructions[0]["entries"]
-                    )
+                if instructions:
+                    # Iterate through all instructions to find TimelineAddEntries
+                    for instruction in instructions:
+                        if (instruction.get("type") == "TimelineAddEntries" and 
+                            "entries" in instruction):
+                            out["threaded_conversation_with_injections_v2"]["instructions"][0]["entries"].extend(
+                                instruction["entries"]
+                            )
         return out
 
     def handle_response(self, response: Response) -> None:


### PR DESCRIPTION
This pull request refines the handling of Twitter timeline data in the `PlaywrightScraper` by improving the logic for processing instructions in the `format_output_json` method. The update ensures that all relevant entries are captured by iterating through instructions instead of assuming the first instruction contains the required data.

### Key change:

**Improved instruction processing in `format_output_json`:**
* Updated the logic to iterate through all instructions and check for `TimelineAddEntries` type, ensuring that entries are properly extended only when they exist in the corresponding instruction. This makes the method more robust and adaptable to variations in the data structure. (`[src/mindvault/bookmarks/twitter/scraper/playwright_scraper.pyL76-R82](diffhunk://#diff-803094944889d9092760ac3e0f5aca04017439d50068d3de6f47ba8a578693c2L76-R82)`)